### PR TITLE
Fix: Use basic authentication in AntflyClient

### DIFF
--- a/src/antfly/client.py
+++ b/src/antfly/client.py
@@ -1,7 +1,7 @@
 """Main client interface for Antfly SDK."""
 
 from typing import Dict, List, Optional, Any
-from antfly_client import Client, AuthenticatedClient
+from antfly_client import Client
 from antfly_client.api.api_table import (
     create_table,
     list_tables,
@@ -48,17 +48,15 @@ class AntflyClient:
         """
         self.base_url = base_url.rstrip("/")
 
+        httpx_args: Dict[str, Any] = {}
         if username and password:
-            self._client = AuthenticatedClient(
-                base_url=self.base_url,
-                auth=(username, password),
-                timeout=timeout,
-            )
-        else:
-            self._client = Client(
-                base_url=self.base_url,
-                timeout=timeout,
-            )
+            httpx_args["auth"] = (username, password)
+
+        self._client = Client(
+            base_url=self.base_url,
+            timeout=timeout,
+            httpx_args=httpx_args,
+        )
 
     # Table operations
 


### PR DESCRIPTION
The AntflyClient was incorrectly using a token-based `AuthenticatedClient` for handling username and password credentials. This was causing authentication to fail.

This change corrects the client's `__init__` method to use the standard `Client` and pass the username and password as a basic auth tuple via `httpx_args`. This aligns with the API's requirements, which, as defined in `openapi.yaml`, uses HTTP Basic Authentication.

The unused `AuthenticatedClient` import has also been removed.