### PR TITLE
Get antfly-sdk runnable

### DIFF
--- a/src/antfly/client.py
+++ b/src/antfly/client.py
@@ -1,6 +1,6 @@
 """Main client interface for Antfly SDK."""
 
-from typing import Any, Optional, cast
+from typing import Any, Optional, Union, cast
 
 from httpx import Timeout
 
@@ -28,9 +28,16 @@ from antfly.client_generated.types import UNSET
 
 from .exceptions import AntflyException
 
+# Type alias: generated API functions type-hint AuthenticatedClient but work with
+# Client too since both have identical interfaces (get_httpx_client, etc.)
+# We use Client with basic auth via httpx_args instead of token-based auth.
+ApiClient = Union[Client, AuthenticatedClient]
+
 
 class AntflyClient:
     """High-level client for interacting with Antfly database."""
+
+    _client: ApiClient
 
     def __init__(
         self,
@@ -54,7 +61,7 @@ class AntflyClient:
         if username and password:
             httpx_args["auth"] = (username, password)
 
-        self._client = Client(
+        self._client: ApiClient = Client(
             base_url=self.base_url,
             timeout=Timeout(timeout),
             httpx_args=httpx_args,
@@ -92,7 +99,7 @@ class AntflyClient:
 
         response = create_table.sync(
             table_name=name,
-            client=cast(AuthenticatedClient, self._client),
+            client=self._client,  # type: ignore[arg-type]
             body=request,
         )
 
@@ -113,7 +120,7 @@ class AntflyClient:
         Raises:
             AntflyException: If listing tables fails
         """
-        response = list_tables.sync(client=cast(AuthenticatedClient, self._client))
+        response = list_tables.sync(client=self._client)  # type: ignore[arg-type]
 
         if isinstance(response, Error):
             raise AntflyException(f"Failed to list tables: {response.error}")
@@ -137,7 +144,7 @@ class AntflyClient:
         """
         response = get_table.sync(
             table_name=name,
-            client=cast(AuthenticatedClient, self._client),
+            client=self._client,  # type: ignore[arg-type]
         )
 
         if isinstance(response, Error):
@@ -159,7 +166,7 @@ class AntflyClient:
         """
         response = drop_table.sync(
             table_name=name,
-            client=cast(AuthenticatedClient, self._client),
+            client=self._client,  # type: ignore[arg-type]
         )
 
         if isinstance(response, Error):
@@ -186,7 +193,7 @@ class AntflyClient:
         response = lookup_key.sync(
             table_name=table,
             key=key,
-            client=cast(AuthenticatedClient, self._client),
+            client=self._client,  # type: ignore[arg-type]
         )
 
         if isinstance(response, Error):
@@ -229,7 +236,7 @@ class AntflyClient:
 
         response = batch_write.sync(
             table_name=table,
-            client=cast(AuthenticatedClient, self._client),
+            client=self._client,  # type: ignore[arg-type]
             body=request,
         )
 

--- a/src/antfly/client.py
+++ b/src/antfly/client.py
@@ -24,7 +24,7 @@ from antfly.client_generated.models import (
     TableSchema,
     TableStatus,
 )
-from antfly.client_generated.types import UNSET
+from antfly.client_generated.types import UNSET, Unset
 
 from .exceptions import AntflyException
 
@@ -221,7 +221,7 @@ class AntflyClient:
             AntflyException: If batch operation fails
         """
         # Convert plain dict to proper BatchRequestInserts model
-        inserts_model: BatchRequestInserts | type[UNSET] = UNSET
+        inserts_model: BatchRequestInserts | Unset = UNSET
         if inserts is not None:
             inserts_model = BatchRequestInserts()
             for key, value in inserts.items():

--- a/src/antfly/client_generated/api/data_operations/batch_write.py
+++ b/src/antfly/client_generated/api/data_operations/batch_write.py
@@ -34,10 +34,9 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[Union[BatchResponse, Error]]:
-    if response.status_code == 201:
-        response_201 = BatchResponse.from_dict(response.json())
-
-        return response_201
+    # Accept both 200 and 201 as success - server may return either
+    if response.status_code in (200, 201):
+        return BatchResponse.from_dict(response.json())
 
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())

--- a/tests/test_import_bugs.py
+++ b/tests/test_import_bugs.py
@@ -1,0 +1,189 @@
+"""Tests for import and type-related bugs in client.py.
+
+These tests verify that the bugs have been FIXED.
+"""
+
+import pytest
+
+
+class TestBug1FixedImportPaths:
+    """Bug #1 Fix: Correct import paths for API modules.
+
+    client.py now correctly imports from data_operations/ and table_management/
+    instead of the non-existent api_table module.
+    """
+
+    def test_api_table_module_does_not_exist(self):
+        """Verify that api_table module still doesn't exist (it never should)."""
+        with pytest.raises((ModuleNotFoundError, ImportError)):
+            from antfly.client_generated.api import api_table  # noqa: F401
+
+    def test_batch_write_is_in_data_operations(self):
+        """Verify batch_write exists in data_operations."""
+        from antfly.client_generated.api.data_operations import batch_write
+        assert hasattr(batch_write, 'sync')
+        assert hasattr(batch_write, 'asyncio')
+
+    def test_lookup_key_is_in_data_operations(self):
+        """Verify lookup_key exists in data_operations."""
+        from antfly.client_generated.api.data_operations import lookup_key
+        assert hasattr(lookup_key, 'sync')
+        assert hasattr(lookup_key, 'asyncio')
+
+    def test_table_operations_are_in_table_management(self):
+        """Verify table operations exist in table_management."""
+        from antfly.client_generated.api.table_management import (
+            create_table,
+            drop_table,
+            get_table,
+            list_tables,
+        )
+        assert hasattr(create_table, 'sync')
+        assert hasattr(drop_table, 'sync')
+        assert hasattr(get_table, 'sync')
+        assert hasattr(list_tables, 'sync')
+
+    def test_client_import_succeeds(self):
+        """Verify that importing AntflyClient now succeeds."""
+        # This should work now that imports are fixed
+        from antfly import AntflyClient
+        assert AntflyClient is not None
+
+    def test_antfly_client_has_expected_methods(self):
+        """Verify AntflyClient has the expected methods."""
+        from antfly import AntflyClient
+
+        # Table operations
+        assert hasattr(AntflyClient, 'create_table')
+        assert hasattr(AntflyClient, 'list_tables')
+        assert hasattr(AntflyClient, 'get_table')
+        assert hasattr(AntflyClient, 'drop_table')
+
+        # Data operations
+        assert hasattr(AntflyClient, 'get')
+        assert hasattr(AntflyClient, 'batch')
+
+        # Query method was removed since endpoints don't exist
+        assert not hasattr(AntflyClient, 'query')
+
+
+class TestBug2FixedCastMisuse:
+    """Bug #2 Fix: Proper BatchRequestInserts model conversion.
+
+    Instead of using cast() which doesn't convert data, the client now
+    properly creates BatchRequestInserts and BatchRequestInsertsAdditionalProperty
+    model instances from plain dicts.
+    """
+
+    def test_cast_does_not_convert_dict_to_model(self):
+        """Verify that cast() doesn't convert a plain dict to a model.
+
+        This demonstrates why we can't use cast() and need proper conversion.
+        """
+        from typing import cast
+        from antfly.client_generated.models import BatchRequestInserts
+
+        plain_dict = {"user:1": {"name": "John"}}
+        casted = cast(BatchRequestInserts, plain_dict)
+
+        # cast() is just a type hint - the value is still a plain dict
+        assert casted is plain_dict
+        assert isinstance(casted, dict)
+        assert not isinstance(casted, BatchRequestInserts)
+
+    def test_batch_request_to_dict_fails_with_plain_dict_inserts(self):
+        """Verify that BatchRequest.to_dict() fails when inserts is a plain dict.
+
+        This demonstrates the bug that existed before the fix.
+        """
+        from typing import cast
+        from antfly.client_generated.models import BatchRequest, BatchRequestInserts
+
+        # This is what the broken client.py used to do
+        plain_dict = {"user:1": {"name": "John"}}
+        inserts = cast(BatchRequestInserts, plain_dict)
+
+        request = BatchRequest(inserts=inserts, deletes=[])
+
+        # This fails because plain_dict doesn't have to_dict()
+        with pytest.raises(AttributeError, match="to_dict"):
+            request.to_dict()
+
+    def test_batch_request_works_with_proper_model(self):
+        """Verify that BatchRequest.to_dict() works with proper model instances."""
+        from antfly.client_generated.models import (
+            BatchRequest,
+            BatchRequestInserts,
+            BatchRequestInsertsAdditionalProperty,
+        )
+
+        # Create proper model instances - this is how the fix works
+        inserts = BatchRequestInserts()
+        prop = BatchRequestInsertsAdditionalProperty()
+        prop.additional_properties = {"name": "John"}
+        inserts["user:1"] = prop
+
+        request = BatchRequest(inserts=inserts, deletes=[])
+
+        # This works with proper model
+        result = request.to_dict()
+        assert "inserts" in result
+        assert "user:1" in result["inserts"]
+
+
+class TestBug3FixedMissingQueryEndpoints:
+    """Bug #3 Fix: Removed references to non-existent query endpoints.
+
+    The query_table and global_query endpoints don't exist in the generated code.
+    The query method has been removed from AntflyClient since it can't work.
+    """
+
+    def test_query_table_does_not_exist(self):
+        """Verify query_table doesn't exist anywhere."""
+        with pytest.raises((ModuleNotFoundError, ImportError)):
+            from antfly.client_generated.api.api_table import query_table  # noqa: F401
+
+    def test_global_query_does_not_exist(self):
+        """Verify global_query doesn't exist anywhere."""
+        with pytest.raises((ModuleNotFoundError, ImportError)):
+            from antfly.client_generated.api.api_table import global_query  # noqa: F401
+
+    def test_query_request_model_does_not_exist(self):
+        """Verify QueryRequest model doesn't exist."""
+        with pytest.raises(ImportError):
+            from antfly.client_generated.models import QueryRequest  # noqa: F401
+
+    def test_query_request_full_text_search_model_does_not_exist(self):
+        """Verify QueryRequestFullTextSearch model doesn't exist."""
+        with pytest.raises(ImportError):
+            from antfly.client_generated.models import QueryRequestFullTextSearch  # noqa: F401
+
+    def test_antfly_client_query_method_removed(self):
+        """Verify that AntflyClient no longer has a query method."""
+        from antfly import AntflyClient
+
+        # The query method was removed since it relied on non-existent endpoints
+        assert not hasattr(AntflyClient, 'query')
+
+
+class TestClientIntegration:
+    """Integration tests for the fixed AntflyClient."""
+
+    def test_client_instantiation(self):
+        """Test that AntflyClient can be instantiated."""
+        from antfly import AntflyClient
+
+        client = AntflyClient(base_url="http://localhost:8080")
+        assert client.base_url == "http://localhost:8080"
+        assert client._client is not None
+
+    def test_client_with_auth(self):
+        """Test that AntflyClient can be instantiated with auth."""
+        from antfly import AntflyClient
+
+        client = AntflyClient(
+            base_url="http://localhost:8080/",
+            username="admin",
+            password="secret",
+        )
+        assert client.base_url == "http://localhost:8080"

--- a/tests/test_import_bugs.py
+++ b/tests/test_import_bugs.py
@@ -21,14 +21,16 @@ class TestBug1FixedImportPaths:
     def test_batch_write_is_in_data_operations(self):
         """Verify batch_write exists in data_operations."""
         from antfly.client_generated.api.data_operations import batch_write
-        assert hasattr(batch_write, 'sync')
-        assert hasattr(batch_write, 'asyncio')
+
+        assert hasattr(batch_write, "sync")
+        assert hasattr(batch_write, "asyncio")
 
     def test_lookup_key_is_in_data_operations(self):
         """Verify lookup_key exists in data_operations."""
         from antfly.client_generated.api.data_operations import lookup_key
-        assert hasattr(lookup_key, 'sync')
-        assert hasattr(lookup_key, 'asyncio')
+
+        assert hasattr(lookup_key, "sync")
+        assert hasattr(lookup_key, "asyncio")
 
     def test_table_operations_are_in_table_management(self):
         """Verify table operations exist in table_management."""
@@ -38,15 +40,17 @@ class TestBug1FixedImportPaths:
             get_table,
             list_tables,
         )
-        assert hasattr(create_table, 'sync')
-        assert hasattr(drop_table, 'sync')
-        assert hasattr(get_table, 'sync')
-        assert hasattr(list_tables, 'sync')
+
+        assert hasattr(create_table, "sync")
+        assert hasattr(drop_table, "sync")
+        assert hasattr(get_table, "sync")
+        assert hasattr(list_tables, "sync")
 
     def test_client_import_succeeds(self):
         """Verify that importing AntflyClient now succeeds."""
         # This should work now that imports are fixed
         from antfly import AntflyClient
+
         assert AntflyClient is not None
 
     def test_antfly_client_has_expected_methods(self):
@@ -54,17 +58,17 @@ class TestBug1FixedImportPaths:
         from antfly import AntflyClient
 
         # Table operations
-        assert hasattr(AntflyClient, 'create_table')
-        assert hasattr(AntflyClient, 'list_tables')
-        assert hasattr(AntflyClient, 'get_table')
-        assert hasattr(AntflyClient, 'drop_table')
+        assert hasattr(AntflyClient, "create_table")
+        assert hasattr(AntflyClient, "list_tables")
+        assert hasattr(AntflyClient, "get_table")
+        assert hasattr(AntflyClient, "drop_table")
 
         # Data operations
-        assert hasattr(AntflyClient, 'get')
-        assert hasattr(AntflyClient, 'batch')
+        assert hasattr(AntflyClient, "get")
+        assert hasattr(AntflyClient, "batch")
 
         # Query method was removed since endpoints don't exist
-        assert not hasattr(AntflyClient, 'query')
+        assert not hasattr(AntflyClient, "query")
 
 
 class TestBug2FixedCastMisuse:
@@ -81,6 +85,7 @@ class TestBug2FixedCastMisuse:
         This demonstrates why we can't use cast() and need proper conversion.
         """
         from typing import cast
+
         from antfly.client_generated.models import BatchRequestInserts
 
         plain_dict = {"user:1": {"name": "John"}}
@@ -97,6 +102,7 @@ class TestBug2FixedCastMisuse:
         This demonstrates the bug that existed before the fix.
         """
         from typing import cast
+
         from antfly.client_generated.models import BatchRequest, BatchRequestInserts
 
         # This is what the broken client.py used to do
@@ -163,7 +169,7 @@ class TestBug3FixedMissingQueryEndpoints:
         from antfly import AntflyClient
 
         # The query method was removed since it relied on non-existent endpoints
-        assert not hasattr(AntflyClient, 'query')
+        assert not hasattr(AntflyClient, "query")
 
 
 class TestBug4FixedTypeMismatch:
@@ -179,18 +185,19 @@ class TestBug4FixedTypeMismatch:
         from antfly.client_generated.client import AuthenticatedClient, Client
 
         # Both should have get_httpx_client method
-        assert hasattr(Client, 'get_httpx_client')
-        assert hasattr(AuthenticatedClient, 'get_httpx_client')
+        assert hasattr(Client, "get_httpx_client")
+        assert hasattr(AuthenticatedClient, "get_httpx_client")
 
         # Both should have get_async_httpx_client method
-        assert hasattr(Client, 'get_async_httpx_client')
-        assert hasattr(AuthenticatedClient, 'get_async_httpx_client')
+        assert hasattr(Client, "get_async_httpx_client")
+        assert hasattr(AuthenticatedClient, "get_async_httpx_client")
 
     def test_api_client_type_alias_exists(self):
         """Verify ApiClient type alias is defined."""
+        from typing import get_args
+
         from antfly.client import ApiClient
         from antfly.client_generated.client import AuthenticatedClient, Client
-        from typing import get_args
 
         # ApiClient should be Union[Client, AuthenticatedClient]
         args = get_args(ApiClient)
@@ -204,8 +211,9 @@ class TestBatchWriteHttpStatus:
     def test_batch_write_parse_response_accepts_200(self):
         """Verify batch_write._parse_response accepts HTTP 200."""
         from unittest.mock import MagicMock
-        from antfly.client_generated.api.data_operations import batch_write
+
         from antfly.client_generated import Client
+        from antfly.client_generated.api.data_operations import batch_write
 
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -219,8 +227,9 @@ class TestBatchWriteHttpStatus:
     def test_batch_write_parse_response_accepts_201(self):
         """Verify batch_write._parse_response accepts HTTP 201."""
         from unittest.mock import MagicMock
-        from antfly.client_generated.api.data_operations import batch_write
+
         from antfly.client_generated import Client
+        from antfly.client_generated.api.data_operations import batch_write
 
         mock_response = MagicMock()
         mock_response.status_code = 201

--- a/tests/test_import_bugs.py
+++ b/tests/test_import_bugs.py
@@ -16,7 +16,7 @@ class TestBug1FixedImportPaths:
     def test_api_table_module_does_not_exist(self):
         """Verify that api_table module still doesn't exist (it never should)."""
         with pytest.raises((ModuleNotFoundError, ImportError)):
-            from antfly.client_generated.api import api_table  # noqa: F401
+            from antfly.client_generated.api import api_table  # type: ignore[attr-defined] # noqa: F401
 
     def test_batch_write_is_in_data_operations(self):
         """Verify batch_write exists in data_operations."""
@@ -147,22 +147,26 @@ class TestBug3FixedMissingQueryEndpoints:
     def test_query_table_does_not_exist(self):
         """Verify query_table doesn't exist anywhere."""
         with pytest.raises((ModuleNotFoundError, ImportError)):
-            from antfly.client_generated.api.api_table import query_table  # noqa: F401
+            from antfly.client_generated.api.api_table import query_table  # type: ignore[import-not-found] # noqa: F401
 
     def test_global_query_does_not_exist(self):
         """Verify global_query doesn't exist anywhere."""
         with pytest.raises((ModuleNotFoundError, ImportError)):
-            from antfly.client_generated.api.api_table import global_query  # noqa: F401
+            from antfly.client_generated.api.api_table import (
+                global_query,  # type: ignore[import-not-found] # noqa: F401
+            )
 
     def test_query_request_model_does_not_exist(self):
         """Verify QueryRequest model doesn't exist."""
         with pytest.raises(ImportError):
-            from antfly.client_generated.models import QueryRequest  # noqa: F401
+            from antfly.client_generated.models import QueryRequest  # type: ignore[attr-defined] # noqa: F401
 
     def test_query_request_full_text_search_model_does_not_exist(self):
         """Verify QueryRequestFullTextSearch model doesn't exist."""
         with pytest.raises(ImportError):
-            from antfly.client_generated.models import QueryRequestFullTextSearch  # noqa: F401
+            from antfly.client_generated.models import (
+                QueryRequestFullTextSearch,  # type: ignore[attr-defined] # noqa: F401
+            )
 
     def test_antfly_client_query_method_removed(self):
         """Verify that AntflyClient no longer has a query method."""


### PR DESCRIPTION
Current version of the module won't run successfully, this gets it usable.

Before:
`$ uv run --with "antfly-sdk @ git+https://github.com/antflydb/antfly-python.git@main" python -c "import antfly; print('done')"`
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/rowan/.cache/uv/archive-v0/o_7zLNKwYuZ9aixyMnr45/lib/python3.12/site-packages/antfly/__init__.py", line 5, in <module>
    from .client import AntflyClient
  File "/Users/rowan/.cache/uv/archive-v0/o_7zLNKwYuZ9aixyMnr45/lib/python3.12/site-packages/antfly/client.py", line 8, in <module>
    from antfly.client_generated.api.api_table import (
ModuleNotFoundError: No module named 'antfly.client_generated.api.api_table'
```

After:
`$ uv run --with "antfly-sdk @ git+https://github.com/dovinmu/antfly-python.git@claude/fix-import-bug-NCnWk" python -c "import antfly; print('done')"`
```
done
```

Bug #1: Fixed imports from non-existent api_table module
- Changed imports to use correct paths: data_operations/batch_write,
  data_operations/lookup_key, and table_management/ for table ops

Bug #2: Fixed cast() misuse with BatchRequestInserts
- cast() only hints types, doesn't convert data
- Now properly creates BatchRequestInserts and
  BatchRequestInsertsAdditionalProperty model instances from dicts

Bug #3: Removed query method referencing non-existent endpoints
- query_table and global_query don't exist in generated code
- QueryRequest and QueryRequestFullTextSearch models don't exist
- Removed the query method until proper endpoints are available

Bug #4 (Medium): Type mismatch - client.py creates Client but casts to AuthenticatedClient when calling APIs. Works at runtime but is a type safety issue.

Bug #5: observed /batch returning a 200 instead of 201 for single-document inserts